### PR TITLE
Add TrueOS(FreeBSD-current) support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Submodules/makelib"]
 	path = Submodules/makelib
-	url = https://github.com/macmade/makelib.git
+	url = https://github.com/drm343/makelib.git

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,17 @@ DIR_SRC             := CoreFoundation/source/
 DIR_RES             := CoreFoundation/
 DIR_TESTS           := Unit-Tests/
 EXT_C               := .c
+EXT_CPP             := .cpp
+EXT_M               := .m
+EXT_MM              := .mm
 EXT_H               := .h
+FILES               := $(call GET_C_FILES, $(DIR_SRC))
+FILES_TESTS         := $(call GET_C_FILES, $(DIR_TESTS))
 CC                  := clang
 FLAGS_OPTIM         := Os
 FLAGS_WARN          := -Werror -Wall
-FLAGS_STD           := c99
+FLAGS_STD_C         := c99
+FLAGS_STD_CPP       := c++11
 FLAGS_OTHER         := -fno-strict-aliasing
 XCODE_PROJECT       := CoreFoundation.xcodeproj
 XCODE_TEST_SCHEME   := CoreFoundation
@@ -71,6 +77,14 @@ example: all
 	
 	@echo -e $(call PRINT,Demo,universal,Compiling the example program)
 	@$(CC) $(FLAGS_WARN) -I$(DIR_INC) -o $(DIR_BUILD_PRODUCTS)$(HOST_ARCH)/test $(call GET_C_FILES, Test/) $(DIR_BUILD_PRODUCTS)$(HOST_ARCH)/$(PRODUCT_LIB).a $(LIBS)
+	@echo -e $(call PRINT,Demo,universal,Runing the example program)
+	@$(DIR_BUILD_PRODUCTS)$(HOST_ARCH)/test
+
+
+example-bsd: all
+	
+	@echo -e $(call PRINT,Demo,universal,Compiling the example program)
+	@$(CC) $(FLAGS_WARN) -I$(DIR_INC) -o $(DIR_BUILD_PRODUCTS)$(HOST_ARCH)/test $(call GET_C_FILES, Test/) $(DIR_BUILD_PRODUCTS)$(HOST_ARCH)/$(PRODUCT_LIB).a /usr/local/lib/libuuid.a $(LIBS)
 	@echo -e $(call PRINT,Demo,universal,Runing the example program)
 	@$(DIR_BUILD_PRODUCTS)$(HOST_ARCH)/test
 	

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ About
 
 This project is a custom implementation of Apple's CoreFoundation framework intended to be used in the [XEOS operating system](http://www.xs-labs.com/en/projects/xeos/) as a base for its Objective-C library.
 
-Actually, the project targets macOS, Linux and Windows, and should compile fine on these platforms.
+Actually, the project targets macOS, Linux, FreeBSD and Windows, and should compile fine on these platforms.
 
 ### Binary compatibility
 
@@ -29,6 +29,8 @@ While the public interface is strictly identical, the private runtime functions 
  - **macOS**  
    Use the provided xCode project, or use the provided makefile.
  - **Linux**  
+   Use the provided makefile.
+ - **FreeBSD**  
    Use the provided makefile.
  - **Windows**  
    Use the provided VisualStudio project.


### PR DESCRIPTION
Add Platform/FreeBSD.mk in makelib for TrueOS support.
CoreFoundation's makefile use gnu-make in TrueOS, and bsd-make not work.